### PR TITLE
Corrected Text/Heading color for bool2.html

### DIFF
--- a/_includes/truth_table.html
+++ b/_includes/truth_table.html
@@ -1,8 +1,8 @@
 <main id="main">
     <!-- Input -->
     <div class="align-center container">
-        <h1>Truth Table Generator</h1>
-        <p>Enter your boolean logic expression in the following format:<br>
+        <h1 class="truth-table">Truth Table Generator</h1>
+        <p class="truth-table">Enter your boolean logic expression in the following format:<br>
             AND = <span class="example">AB</span>&emsp;
             OR = <span class="example">A+B</span>&emsp;
             NOT = <span class="example">A'</span><br>
@@ -34,7 +34,7 @@
         padding: 50px;
     }
 
-    h1 {
+    .truth-table h1 {
         color: black;
         margin: 0;
     }
@@ -51,7 +51,7 @@
         max-width: 100%;
     }
 
-    p {
+    .truth-table p {
         color: #444;
         font-size: 16px;
         line-height: 24px;


### PR DESCRIPTION
Solves #60 
Added approraite class names in _includes/truth_table.html to rectify the text and heading color for docs/bool2.html when in Dark Mode.

**Before**
![image](https://user-images.githubusercontent.com/47032027/68702582-16505300-05af-11ea-81e7-64419046ae37.png)

![image](https://user-images.githubusercontent.com/47032027/68702588-19e3da00-05af-11ea-9f3d-885bfaa26821.png)

**After** 
![image](https://user-images.githubusercontent.com/47032027/68702596-1d776100-05af-11ea-98b5-f55d3f782953.png)

![image](https://user-images.githubusercontent.com/47032027/68702603-210ae800-05af-11ea-8502-b26ec66692dc.png)

**In Light Mode**
![image](https://user-images.githubusercontent.com/47032027/68733306-378b6080-05fc-11ea-8633-5a584522b686.png)
